### PR TITLE
Add utility functions and ability to dynamically set host

### DIFF
--- a/PHPToolkit/NSPHPClient.php
+++ b/PHPToolkit/NSPHPClient.php
@@ -171,6 +171,18 @@ function cleanUpNamespaces($xml_root)
     return $xml_root;
 }
 
+function getNetSuiteHosts($account_id) {
+    $NetSuiteService = new NetSuiteService();
+    $NetSuiteService->setPassport($account_id, null, null, null);
+    
+    $dataCenterUrlsRequest = new GetDataCenterUrlsRequest();
+    $dataCenterUrlsRequest->account = $account_id;
+    $dataCenterUrlsResponse = $NetSuiteService->getDataCenterUrls($dataCenterUrlsRequest);
+
+    return $dataCenterUrlsResponse->getDataCenterUrlsResult->dataCenterUrls;
+}
+
+
 class NSPHPClient {
     private $nsversion = "2012_2r1";    
 
@@ -182,9 +194,14 @@ class NSPHPClient {
     public $generated_from_endpoint = "";
 
 
-    protected function __construct($wsdl=null, $options=array()) {
+    protected function __construct($wsdl=null, $options=array(), $accountId=null) {
         global $nshost, $nsendpoint;
         global $debuginfo;
+
+        if (!empty($accountId)) {
+            $hosts = getNetSuiteHosts($accountId);
+            $nshost = $hosts->webservicesDomain;
+        }
 
         if (!isset($wsdl)) {
              if (!isset($nshost)) {
@@ -361,7 +378,6 @@ class NSPHPClient {
         return $response;
 
     }
-
 }
 
 

--- a/PHPToolkit/NetSuiteService.php
+++ b/PHPToolkit/NetSuiteService.php
@@ -114586,8 +114586,8 @@ class NetSuiteService extends NSPHPClient {
 	 * @param string $wsdl WSDL location for this service
 	 * @param array $options Options for the SoapClient
 	 */
-	public function __construct($wsdl=null, $options=array()) {
-		parent::__construct($wsdl, $options);
+	public function __construct($wsdl=null, $options=array(), $accountId=null) {
+		parent::__construct($wsdl, $options, $accountId);
 	}
 
 	/**


### PR DESCRIPTION
I have added a parameter to the constructor in order to initialize the Connection with the appropriate  NetSuite domain. 
- First I do not like the solution I have come up with.
- Second the first parameter is a wsdl url however $nshost is used in creating the wsdl and the location header and that needs the correct domain as well.

I have also added a public and one private function to calculate the authentication token for SSO use.
