### PR TITLE
Fix netsuite sync/push issue

### DIFF
--- a/PHPToolkit/NSPHPClient.php
+++ b/PHPToolkit/NSPHPClient.php
@@ -195,8 +195,10 @@ class NSPHPClient {
 
 
     protected function __construct($wsdl=null, $options=array(), $accountId=null, $sandbox=false) {
-        global $nshost, $nsendpoint;
+        global $nsendpoint;
         global $debuginfo;
+
+        $nshost = "https://webservices.netsuite.com";
 
         if (!empty($accountId)) {
             $hosts = getNetSuiteHosts($accountId);

--- a/PHPToolkit/NSconfig.php
+++ b/PHPToolkit/NSconfig.php
@@ -1,7 +1,6 @@
 <?php
 
 // Mark them in global context so that NSPHPClient can always find them.
-global $nsendpoint, $nshost;
+global $nsendpoint;
 
 $nsendpoint = "2012_2";
-$nshost = "https://webservices.netsuite.com";


### PR DESCRIPTION
So because the $nshost variable was a global the SoapClient would try to find domains in getNetSuiteHosts() with the last $nshost used. After you push a lead on staging that gets set to webservices.sandbox.netsuite.com and then we try to get the hosts with that url but the account id we are using to look up the hosts does not exist on the sandbox environment.
### Testing Notes

To replicate:
- [x] Change user to trigger NetsuiteSyncUser
- [x] Make sure that the ENABLE_SIGNUP_NSCORP = true
- [x] singup and trigger NetsuitePushLead
- [x] Make change to user again this time it should fail

To get code that fixes it
- [x] Get this code 
- [x] Restart queue

---

After this code is merged, merge https://github.com/TribeHR/TribeHR/pull/2028 so that composer update grabs the new code for everyone
https://tribehr.atlassian.net/browse/WEB-4834
